### PR TITLE
fix: goreleaser configuration update to v2

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,7 +33,7 @@ archives:
     formats: [ 'tar.gz' ]
     format_overrides:
       - goos: windows
-        formats: zip
+        formats: [ 'zip' ]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - README.md

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,5 @@
 # GoReleaser configuration for azkeyget
+version: 2
 project_name: azkeyget
 
 before:
@@ -27,12 +28,12 @@ builds:
 
 archives:
   - id: azkeyget
-    builds:
+    ids:
       - azkeyget
-    format: tar.gz
+    formats: [ 'tar.gz' ]
     format_overrides:
       - goos: windows
-        format: zip
+        formats: zip
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - README.md
@@ -42,7 +43,7 @@ checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 changelog:
   sort: asc


### PR DESCRIPTION
This pull request updates the `.goreleaser.yaml` configuration to align with the latest GoReleaser schema and improve consistency in build and archive definitions. The changes ensure compatibility and clearer configuration for future releases.

GoReleaser configuration updates:

* Set the configuration `version` to `2` to use the latest GoReleaser schema.
* Changed the `archives` section to use `ids` and `formats` arrays for specifying build artifacts and their formats, replacing the older `builds` and `format` keys.
* Updated the `snapshot` section to use `version_template` instead of `name_template` for snapshot versioning.