### PR TITLE
ci: add monthly auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,84 @@
+name: Auto Release
+
+on:
+  schedule:
+    # First day of each month at 08:00 UTC (after Monday dependabot PRs land)
+    - cron: '0 8 1 * *'
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create release tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine next version
+        id: version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUMP: ${{ inputs.bump || 'patch' }}
+        run: |
+          set -euo pipefail
+
+          latest=$(git tag --list 'v*' --sort=-v:refname | head -n1)
+          if [ -z "$latest" ]; then
+            latest="v0.0.0"
+          fi
+          echo "Latest tag: $latest"
+
+          commits_since=$(git rev-list "${latest}..HEAD" --count)
+          echo "Commits since ${latest}: ${commits_since}"
+          if [ "$commits_since" -eq 0 ]; then
+            echo "No new commits since ${latest}; skipping release."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          IFS='.' read -r major minor patch <<EOF
+          ${latest#v}
+          EOF
+
+          case "$BUMP" in
+            major) major=$((major + 1)); minor=0; patch=0 ;;
+            minor) minor=$((minor + 1)); patch=0 ;;
+            patch) patch=$((patch + 1)) ;;
+            *) echo "Unknown bump type: $BUMP" >&2; exit 1 ;;
+          esac
+
+          next="v${major}.${minor}.${patch}"
+          echo "Next version: ${next}"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "tag=${next}" >> "$GITHUB_OUTPUT"
+          echo "previous=${latest}" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        if: steps.version.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          PREVIOUS: ${{ steps.version.outputs.previous }}
+        run: |
+          set -euo pipefail
+          gh release create "$TAG" \
+            --target "${GITHUB_SHA}" \
+            --title "Release $TAG" \
+            --notes "Automated release bumping dependencies since ${PREVIOUS}." \
+            --generate-notes


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/auto-release.yml` to cut a patch release on the 1st of each month, paired with dependabot's weekly updates
- Supports `workflow_dispatch` with `patch`/`minor`/`major` inputs for manual bumps
- Skips when no commits have landed since the latest `v*` tag; otherwise creates a GitHub release (which triggers the existing `release.yml` goreleaser pipeline)

## Test plan
- [ ] Merge, then trigger `workflow_dispatch` with `patch` to confirm the tag/release is created and goreleaser runs
- [ ] Verify the scheduled run is skipped when no commits have landed since the last tag

Generated by Claude Code